### PR TITLE
Supply run remote activation glitch fix

### DIFF
--- a/Missions/[55-2hc]warfarev2_073v48co.chernarus/Client/Module/supplyMission/supplyMissionStart.sqf
+++ b/Missions/[55-2hc]warfarev2_073v48co.chernarus/Client/Module/supplyMission/supplyMissionStart.sqf
@@ -13,7 +13,7 @@ if (_supplyMissionAlreadyActiveInTown) exitWith {
     format ["This town doesn't have enough supplies to be collected yet! You can start a supply mission in towns that have [+SUPPLY] added after their SV on map."] call GroupChatMessage;
 };
 
-if (typeOf cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC', 'WarfareSupplyTruck_INS', 'WarfareSupplyTruck_Gue', 'WarfareSupplyTruck_CDF', 'UralSupply_TK_EP1', 'MtvrSupply_DES_EP1']) then {
+if (typeOf cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC', 'WarfareSupplyTruck_INS', 'WarfareSupplyTruck_Gue', 'WarfareSupplyTruck_CDF', 'UralSupply_TK_EP1', 'MtvrSupply_DES_EP1'] && (cursorTarget distance player < 50)) then {
     WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK = cursorTarget;
     WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK setVariable ["SupplyFromTown", _sourceTown, true];
 

--- a/Missions/[55-2hc]warfarev2_073v48co.chernarus/Client/Module/supplyMission/supplyMissionStart.sqf
+++ b/Missions/[55-2hc]warfarev2_073v48co.chernarus/Client/Module/supplyMission/supplyMissionStart.sqf
@@ -1,4 +1,4 @@
-private ['_sourceTown', '_TownSupplyLastMission', '_associatedSupplyTruck', '_supplyAmount','_supplyMissionAlreadyActiveInTown'];
+private ['_sourceTown', '_TownSupplyLastMission', '_associatedSupplyTruck', '_supplyAmount', '_supplyMissionAlreadyActiveInTown', '_cursorTarget'];
 
 _sourceTown = call GetClosestFriendlyLocation;
 WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK = objNull;
@@ -13,8 +13,10 @@ if (_supplyMissionAlreadyActiveInTown) exitWith {
     format ["This town doesn't have enough supplies to be collected yet! You can start a supply mission in towns that have [+SUPPLY] added after their SV on map."] call GroupChatMessage;
 };
 
-if (typeOf cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC', 'WarfareSupplyTruck_INS', 'WarfareSupplyTruck_Gue', 'WarfareSupplyTruck_CDF', 'UralSupply_TK_EP1', 'MtvrSupply_DES_EP1'] && (cursorTarget distance player < 50)) then {
-    WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK = cursorTarget;
+_cursorTarget = cursorTarget;
+
+if (typeOf _cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC', 'WarfareSupplyTruck_INS', 'WarfareSupplyTruck_Gue', 'WarfareSupplyTruck_CDF', 'UralSupply_TK_EP1', 'MtvrSupply_DES_EP1'] && (_cursorTarget distance player < 50)) then {
+    WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK = _cursorTarget;
     WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK setVariable ["SupplyFromTown", _sourceTown, true];
 
     _supplyAmount = (_sourceTown getVariable "supplyValue") * WFBE_C_ECONOMY_SUPPLY_MISSION_MULTIPLIER;

--- a/Missions_Vanilla/[61-2hc]warfarev2_073v48co.takistan/Client/Module/supplyMission/supplyMissionStart.sqf
+++ b/Missions_Vanilla/[61-2hc]warfarev2_073v48co.takistan/Client/Module/supplyMission/supplyMissionStart.sqf
@@ -13,7 +13,7 @@ if (_supplyMissionAlreadyActiveInTown) exitWith {
     format ["This town doesn't have enough supplies to be collected yet! You can start a supply mission in towns that have [+SUPPLY] added after their SV on map."] call GroupChatMessage;
 };
 
-if (typeOf cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC', 'WarfareSupplyTruck_INS', 'WarfareSupplyTruck_Gue', 'WarfareSupplyTruck_CDF', 'UralSupply_TK_EP1', 'MtvrSupply_DES_EP1']) then {
+if (typeOf cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC', 'WarfareSupplyTruck_INS', 'WarfareSupplyTruck_Gue', 'WarfareSupplyTruck_CDF', 'UralSupply_TK_EP1', 'MtvrSupply_DES_EP1'] && (cursorTarget distance player < 50)) then {
     WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK = cursorTarget;
     WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK setVariable ["SupplyFromTown", _sourceTown, true];
 

--- a/Missions_Vanilla/[61-2hc]warfarev2_073v48co.takistan/Client/Module/supplyMission/supplyMissionStart.sqf
+++ b/Missions_Vanilla/[61-2hc]warfarev2_073v48co.takistan/Client/Module/supplyMission/supplyMissionStart.sqf
@@ -1,4 +1,4 @@
-private ['_sourceTown', '_TownSupplyLastMission', '_associatedSupplyTruck', '_supplyAmount','_supplyMissionAlreadyActiveInTown'];
+private ['_sourceTown', '_TownSupplyLastMission', '_associatedSupplyTruck', '_supplyAmount', '_supplyMissionAlreadyActiveInTown', '_cursorTarget'];
 
 _sourceTown = call GetClosestFriendlyLocation;
 WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK = objNull;
@@ -13,8 +13,10 @@ if (_supplyMissionAlreadyActiveInTown) exitWith {
     format ["This town doesn't have enough supplies to be collected yet! You can start a supply mission in towns that have [+SUPPLY] added after their SV on map."] call GroupChatMessage;
 };
 
-if (typeOf cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC', 'WarfareSupplyTruck_INS', 'WarfareSupplyTruck_Gue', 'WarfareSupplyTruck_CDF', 'UralSupply_TK_EP1', 'MtvrSupply_DES_EP1'] && (cursorTarget distance player < 50)) then {
-    WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK = cursorTarget;
+_cursorTarget = cursorTarget;
+
+if (typeOf _cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC', 'WarfareSupplyTruck_INS', 'WarfareSupplyTruck_Gue', 'WarfareSupplyTruck_CDF', 'UralSupply_TK_EP1', 'MtvrSupply_DES_EP1'] && (_cursorTarget distance player < 50)) then {
+    WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK = _cursorTarget;
     WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK setVariable ["SupplyFromTown", _sourceTown, true];
 
     _supplyAmount = (_sourceTown getVariable "supplyValue") * WFBE_C_ECONOMY_SUPPLY_MISSION_MULTIPLIER;


### PR DESCRIPTION
This fix disables the currently prevalent supply mission glitch (where player could just keep a supply truck next to a remote CC and activate supply mission remotely with that truck, resulting in instant supply collection at base)