### PR TITLE
Add "supply truck too far" notification

### DIFF
--- a/Missions/[55-2hc]warfarev2_073v48co.chernarus/Client/Module/supplyMission/supplyMissionStart.sqf
+++ b/Missions/[55-2hc]warfarev2_073v48co.chernarus/Client/Module/supplyMission/supplyMissionStart.sqf
@@ -27,6 +27,10 @@ if (typeOf _cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC',
     WFBE_Client_PV_SupplyMissionStarted = [player, WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK, _sourceTown, sideJoined];
     publicVariableServer "WFBE_Client_PV_SupplyMissionStarted";
     
+} else {
+    if (_cursorTarget distance player >= 50) then {
+        format ["Your supply truck is too far away to collect the supply from this town!"] call GroupChatMessage;
+    };
 };
 
 sleep 0.1;

--- a/Missions_Vanilla/[61-2hc]warfarev2_073v48co.takistan/Client/Module/supplyMission/supplyMissionStart.sqf
+++ b/Missions_Vanilla/[61-2hc]warfarev2_073v48co.takistan/Client/Module/supplyMission/supplyMissionStart.sqf
@@ -27,6 +27,10 @@ if (typeOf _cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC',
     WFBE_Client_PV_SupplyMissionStarted = [player, WFBE_CL_VAR_ASSOCIATED_SUPPLY_TRUCK, _sourceTown, sideJoined];
     publicVariableServer "WFBE_Client_PV_SupplyMissionStarted";
     
+} else {
+    if (_cursorTarget distance player >= 50) then {
+        format ["Your supply truck is too far away to collect the supply from this town!"] call GroupChatMessage;
+    };
 };
 
 sleep 0.1;


### PR DESCRIPTION
Minor addition: players get notified with a group chat message if they try to load supplies to a supply truck that's too far away from the player's position (limit is 50 meters currently).