### PR TITLE
Fix 'supply truck too far' notification being run during JIP

### DIFF
--- a/Missions/[55-2hc]warfarev2_073v48co.chernarus/Client/Module/supplyMission/supplyMissionStart.sqf
+++ b/Missions/[55-2hc]warfarev2_073v48co.chernarus/Client/Module/supplyMission/supplyMissionStart.sqf
@@ -28,7 +28,7 @@ if (typeOf _cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC',
     publicVariableServer "WFBE_Client_PV_SupplyMissionStarted";
     
 } else {
-    if (_cursorTarget distance player >= 50) then {
+    if (typeOf _cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC', 'WarfareSupplyTruck_INS', 'WarfareSupplyTruck_Gue', 'WarfareSupplyTruck_CDF', 'UralSupply_TK_EP1', 'MtvrSupply_DES_EP1'] && (_cursorTarget distance player >= 50)) then {
         format ["Your supply truck is too far away to collect the supply from this town!"] call GroupChatMessage;
     };
 };

--- a/Missions_Vanilla/[61-2hc]warfarev2_073v48co.takistan/Client/Module/supplyMission/supplyMissionStart.sqf
+++ b/Missions_Vanilla/[61-2hc]warfarev2_073v48co.takistan/Client/Module/supplyMission/supplyMissionStart.sqf
@@ -28,7 +28,7 @@ if (typeOf _cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC',
     publicVariableServer "WFBE_Client_PV_SupplyMissionStarted";
     
 } else {
-    if (_cursorTarget distance player >= 50) then {
+    if (typeOf _cursorTarget in ['WarfareSupplyTruck_RU', 'WarfareSupplyTruck_USMC', 'WarfareSupplyTruck_INS', 'WarfareSupplyTruck_Gue', 'WarfareSupplyTruck_CDF', 'UralSupply_TK_EP1', 'MtvrSupply_DES_EP1'] && (_cursorTarget distance player >= 50)) then {
         format ["Your supply truck is too far away to collect the supply from this town!"] call GroupChatMessage;
     };
 };


### PR DESCRIPTION
This change ensures backwards compatibility while still preventing the extra 'supply truck too far' notification message from appearing when player spawns ingame. (A bit hacky, but it works.)